### PR TITLE
Защита полей запроса от переопределения через $form

### DIFF
--- a/lib/web/controllers.p
+++ b/lib/web/controllers.p
@@ -915,6 +915,7 @@ locals
 @create[aOptions]
 ## aOptions — хеш с переменными объекта, которые надо заменить. [Для тестов.]
 ## aOptions.useXForwarded(false) — использовать для полей HOST и PORT заголовки X-Forwarded-Host и X-Forwarded-Port.
+## aOptions.protect — хэш защищённых полей: их значения можно установить только через @assign, не через форму.
   $aOptions[^hash::create[$aOptions]]
 
   $self.ifdef[$pfClass:ifdef]

--- a/lib/web/controllers.p
+++ b/lib/web/controllers.p
@@ -920,6 +920,7 @@ locals
   $self.ifdef[$pfClass:ifdef]
   $self.ifcontains[$pfClass:ifcontains]
   $self.__CONTEXT__[^hash::create[]]
+  $self.__PROTECT__[^hash::create[$aOptions.protect]]
 
   $self.form[^self.ifdef[$aOptions.form]{$form:fields}]
   $self.tables[^self.ifdef[$aOptions.tables]{$form:tables}]
@@ -1004,7 +1005,7 @@ locals
   }
 
 @GET_DEFAULT[aName]
-  $result[^if(^self.__CONTEXT__.contains[$aName]){$self.__CONTEXT__.[$aName]}{$form.[$aName]}]
+  $result[^if(^self.__CONTEXT__.contains[$aName]){$self.__CONTEXT__.[$aName]}(!^self.__PROTECT__.contains[$name]){$form.[$aName]}]
 
 @GET_BODY_FILE[]
   $result[^if(def $self._BODY_FILE){$self._BODY_FILE}{$self.request:body-file}]


### PR DESCRIPTION
Столкнулся с таким случаем.

В шаблоне страниц есть код:

^if(def $self.REQUEST.session){
	… $self.REQUEST.session.sid …
}

$REQUEST.session устанавливается middleware, который включён только в той части сайта, где требуется аутентификация пользователя — на большинстве страниц $self.REQUEST.session пуст.

Злоумышленник делает запрос /?user_id=1'&id=2'&phpsessid=3'&cookie=4'&page=5'&site=6'&coin=7'&user=8'&userid=9'&pass=10'&password=11'&email=12'&session=13'&api=14'&api_key=15'&expires=16'&expire=17'&date=18'&time=19'&path=20'&php=21'&bit=22'&bitcoin=23'&eth=24'&ethereum=25'&file=26', что из-за @GET_DEFAULT[] pfRequest делает поле $self.REQUEST.session определённым, но там не объект сессии, а строка — получаем ошибку «element can not be fetched from string».

Можно, конечно, везде более точно проверять $self.REQUEST.session, но я решил вопрос добавив pfRequest опцию конструктора $.protect[], где перечисляются те поля, которые могут присутствовать только в __CONTEXT__ и @GET_DEFAULT[] не ищет их в $form.

https://github.com/unhandled-exception/pf2/issues/55