### PR TITLE
Добавил поддержку SKIP LOCKED в pfSQLQueue

### DIFF
--- a/lib/sql/models/generics/queue/sql_queue.p
+++ b/lib/sql/models/generics/queue/sql_queue.p
@@ -4,7 +4,7 @@
 pfSQLQueue
 
 ## Класс для работы с очередью в базе данных
-## Требует поддержки семантики SELECT-FOR-UPDATE в СУБД
+## Требует поддержки семантики SELECT-FOR-UPDATE в СУБД (MySQL, Postgres)
 ## На основе статьи Якова Сироткина — http://telamon.ru/articles/async.html
 
 @OPTIONS
@@ -19,6 +19,7 @@ pfSQLTable
 @create[aTableName;aOptions]
 ## aOptions.defaultTaskType[0] — значение типа задачи по-умолчанию
 ## aOptions.interval(0.0) — интервал в минутах между попытками обработки задач.
+## aOptions.skipLocked(false) — пропускать заблокированные задачи и брать свободные (требует for update skip lockedб MySQL >= 8, Posrtgres >= 9.5)
 ##                          Если ноль, то используем 2 в степени attempt минут.
   ^BASE:create[$aTableName;$aOptions]
 
@@ -32,14 +33,18 @@ pfSQLTable
     $.attempt[$.processor[uint] $.default(0) $.label[]]
     $.createdAt[$.dbField[created_at] $.processor[auto_now] $.skipOnUpdate(true) $.widget[none]]
   ]
-
   $self._defaultOrderBy[$.processTime[asc] $.taskID[asc]]
 
   $self._interval(^aOptions.interval.double(0.0))
+  $self._skipLocked(^aOptions.skipLocked.bool(false))
 
 @fetchOne[aOptions]
 ## Достает из базы ровно одну задачу
-  $result[^self.fetch[^hash::create[$aOptions] $.limit(1) $.asHash(true)]]
+  $result[^self.fetch[
+    ^hash::create[$aOptions]
+    $.limit(1)
+    $.asHash(true)
+  ]]
   $result[^result._at[first]]
 
 @fetch[aOptions]
@@ -48,10 +53,16 @@ pfSQLTable
 ## aOptions.limit(1)
   ^self.cleanMethodArgument[]
 
-  $lTail[^switch[$self.CSQL.serverType]{
-    ^case[pgsql]{FOR UPDATE OF "$self.TABLE_NAME"}
-    ^case[DEFAULT]{FOR UPDATE}
-  }]
+  $lTail[FOR UPDATE]
+  ^switch[$self.CSQL.serverType]{
+    ^case[pgsql;postgresql]{
+      $lTail[$lTail OF "$self.TABLE_NAME"]
+    }
+  }
+
+  ^if($self._skipLocked){
+    $lTail[$lTail SKIP LOCKED]
+  }
 
   ^self.CSQL.transaction{
     $lConds[^hash::create[$aOptions]]


### PR DESCRIPTION
Инфраструктуры тестов для MySQL/Postgres пока нет. Приниципиальной проблемы нет — поднимаем контейнеры, аналогично httpbin, после чего работаем аналогично sqlite. Добавлю тесты очень скоро :)