### PR TITLE
В lib/console/commands/pgsql.p@pfPgSQLCommand.vacuum делаем вакуум только для таблиц (без view, внешних и временных табличе), чтобы избежать предупреждений Постгреса

### DIFF
--- a/lib/console/commands/pgsql.p
+++ b/lib/console/commands/pgsql.p
@@ -296,6 +296,7 @@ pfConsoleCommandWithSubcommands
            table_schema
       from information_schema.tables
      where table_schema not in ('pg_catalog', 'information_schema')
+           and table_type = 'BASE TABLE'
            ^if(def $aArgs.1){
              and table_name like '^taint[$aArgs.1]%'
            }


### PR DESCRIPTION
https://www.postgresql.org/docs/13/infoschema-tables.html